### PR TITLE
Fix typo causing Issue #135

### DIFF
--- a/scss/sectionlayout/sectionstyle6.scss
+++ b/scss/sectionlayout/sectionstyle6.scss
@@ -51,7 +51,7 @@ li.current h3.sectionname {
 }
 
 h3.sectionname.dimmed_text {
-    border-top: 10px solid $gray !important;
+    border-top: 10px solid $gray-100 !important;
 }
 
 li.section.hidden .content {


### PR DESCRIPTION
Prompted by [this comment] (https://github.com/dbnschools/moodle-theme_fordson/issues/135#issuecomment-839976435), I've changed the typo from `$gray`to`$gray-100` and everything seems to work now.